### PR TITLE
Evita que valide subcadenas dentro del valor dado

### DIFF
--- a/lib/spanish_vat_validators.rb
+++ b/lib/spanish_vat_validators.rb
@@ -12,7 +12,7 @@ module ActiveModel::Validations
     def validate_nif(v)
       return false if v.nil? || v.empty?
       value = v.upcase
-      return false unless value.match(/[0-9]{8}[a-z]/i)
+      return false unless value.match(/^[0-9]{8}[a-z]$/i)
       letters = "TRWAGMYFPDXBNJZSQVHLCKE"
       check = value.slice!(value.length - 1..value.length - 1)
       calculated_letter = letters[value.to_i % 23].chr
@@ -23,7 +23,7 @@ module ActiveModel::Validations
     def validate_cif(v)
       return false if v.nil? || v.empty?
       value = v.clone
-      return false unless value.match(/[a-wyz][0-9]{7}[0-9a-z]/i)
+      return false unless value.match(/^[a-wyz][0-9]{7}[0-9a-z]$/i)
       pares = 0
       impares = 0
       uletra = ["J", "A", "B", "C", "D", "E", "F", "G", "H", "I"]
@@ -57,7 +57,7 @@ module ActiveModel::Validations
     def validate_nie(v)
 	  return false if v.nil? || v.empty?
       value = v.upcase
-      return false unless value.match(/[xyz][0-9]{7}[a-z]/i)
+      return false unless value.match(/^[xyz][0-9]{7}[a-z]$/i)
       value[0] = {"X" => "0", "Y" => "1", "Z" => "2"}[value[0]]
       validate_nif(value)
     end


### PR DESCRIPTION
Añadidos ^ y $ a las expresiones regulares para garantizar que toda la cadena es válida.