### PR TITLE
fixed bug on cif validation

### DIFF
--- a/lib/spanish_vat_validators.rb
+++ b/lib/spanish_vat_validators.rb
@@ -37,11 +37,11 @@ module ActiveModel::Validations
         [1,3,5,7].collect do |cont|
           xxx = (2 * texto[cont,1].to_i).to_s + "0"
           impares += xxx[0,1].to_i + xxx[1,1].to_i
-          pares += texto[cont+1,1].to_i
         end
 
-        xxx = (2 * texto[8,1].to_i).to_s + "0"
-        impares += xxx[0,1].to_i + xxx[1,1].to_i
+        [2,4,6].collect do |cont|
+          pares += texto[cont,1].to_i
+        end
 
         suma = (pares + impares).to_s
         unumero = suma.last.to_i


### PR DESCRIPTION
Solucionado bug que valida de forma errónea los CIF. Las operaciones para calcular el dígito de control se realizan sobre los siete dígitos centrales, mientras que el código original realiza las operaciones sobre los 8 finales.

Por ejemplo, el CIF válido A58818501 no pasaba la validación.

Fuente: https://es.wikipedia.org/wiki/C%C3%B3digo_de_identificaci%C3%B3n_fiscal#Formato_del_c.C3.B3digo