### PR TITLE
Simplify slice! call on validate_nif method

### DIFF
--- a/lib/spanish_vat_validators.rb
+++ b/lib/spanish_vat_validators.rb
@@ -14,7 +14,7 @@ module ActiveModel::Validations
       value = v.upcase
       return false unless value.match(/^[0-9]{8}[a-z]$/i)
       letters = "TRWAGMYFPDXBNJZSQVHLCKE"
-      check = value.slice!(value.length - 1..value.length - 1)
+      check = value.slice!(value.length - 1)
       calculated_letter = letters[value.to_i % 23].chr
       return check === calculated_letter
     end


### PR DESCRIPTION
I don't see the point of use `slice!(x..x)` instead of just `slice!(x)`

(On Ruby 2.3.1)
![screenshot from 2017-02-22 17 29 16](https://cloud.githubusercontent.com/assets/1860816/23221184/ac94ea96-f924-11e6-8625-13f65d96af9e.png)

Maybe I'm missing something, in any case, thanks for this gem!

