### PR TITLE
Use correct REGEX start/end string delimitators

### DIFF
--- a/lib/spanish_vat_validators.rb
+++ b/lib/spanish_vat_validators.rb
@@ -13,7 +13,7 @@ module ActiveModel::Validations
     def validate_nif(v)
       return false if v.nil? || v.empty?
       value = v.upcase
-      return false unless value.match(/^[0-9]{8}[a-z]$/i)
+      return false unless value.match(/\A[0-9]{8}[a-z]\z/i)
       letters = "TRWAGMYFPDXBNJZSQVHLCKE"
       check = value.slice!(value.length - 1)
       calculated_letter = letters[value.to_i % 23].chr
@@ -24,12 +24,12 @@ module ActiveModel::Validations
     def validate_cif(v)
       return false if v.nil? || v.empty?
       value = v.clone
-      return false unless value.match(/^[a-wyz][0-9]{7}[0-9a-z]$/i)
+      return false unless value.match(/\A[a-wyz][0-9]{7}[0-9a-z]\z/i)
       even = 0
       odd = 0
       uletter = ["J", "A", "B", "C", "D", "E", "F", "G", "H", "I"]
       text = value.upcase
-      regular = /^[ABCDEFGHJKLMNPQRSVW]\d{7}[0-9,A-J]$/#g);
+      regular = /\A[ABCDEFGHJKLMNPQRSVW]\d{7}[0-9,A-J]\z/i
       if regular.match(value).blank?
         false
       else
@@ -54,7 +54,7 @@ module ActiveModel::Validations
     def validate_nie(v)
       return false if v.nil? || v.empty?
       value = v.upcase
-      return false unless value.match(/^[xyz][0-9]{7}[a-z]$/i)
+      return false unless value.match(/\A[xyz][0-9]{7}[a-z]\z/i)
       value[0] = {"X" => "0", "Y" => "1", "Z" => "2"}[value[0]]
       validate_nif(value)
     end

--- a/spec/spanish_vat_validators_spec.rb
+++ b/spec/spanish_vat_validators_spec.rb
@@ -22,6 +22,26 @@ describe ActiveModel::Validations::ValidSpanishVatValidator do
         should_be_invalid(record, 'invalid')
       end
     end
+
+    it 'adds errors when there are surrounding characters' do
+      %w[22472947S S6185663I Y8527549Z].each do |identification_number|
+        surrounded = %W[junk#{identification_number} #{identification_number}junk junk#{identification_number}junk]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
+
+    it 'adds errors when there are surrounding lines' do
+      %w[22472947S S6185663I Y8527549Z].each do |identification_number|
+        surrounded = %W[\n#{identification_number} #{identification_number}\n \n#{identification_number}\n]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
   end
 end
 
@@ -46,6 +66,28 @@ describe ActiveModel::Validations::ValidSpanishIdValidator do
       %w[1234 96380632 284-59349T 5696134L S6185663I invalid_zip].each do |identification_number|
         record = build_record(identification_number)
         should_be_invalid(record, 'invalid')
+      end
+    end
+
+    it 'adds errors when there are surrounding characters' do
+      %w[22472947S 96380632Y 28459349T 35696134L 86159868M 29052409M
+         Y8527549Z Y8305424T X9393496C X0012309G Y9370869Q Y2995306F].each do |identification_number|
+        surrounded = %W[junk#{identification_number} #{identification_number}junk junk#{identification_number}junk]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
+
+    it 'adds errors when there are surrounding lines' do
+      %w[22472947S 96380632Y 28459349T 35696134L 86159868M 29052409M
+         Y8527549Z Y8305424T X9393496C X0012309G Y9370869Q Y2995306F].each do |identification_number|
+        surrounded = %W[\n#{identification_number} #{identification_number}\n \n#{identification_number}\n]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
       end
     end
   end
@@ -73,6 +115,26 @@ describe ActiveModel::Validations::ValidNifValidator do
         should_be_invalid(record, 'invalid')
       end
     end
+
+    it 'adds errors when there are surrounding characters' do
+      %w[22472947S 96380632Y 28459349T 35696134L 86159868M 29052409M].each do |identification_number|
+        surrounded = %W[junk#{identification_number} #{identification_number}junk junk#{identification_number}junk]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
+
+    it 'adds errors when there are surrounding lines' do
+      %w[22472947S 96380632Y 28459349T 35696134L 86159868M 29052409M].each do |identification_number|
+        surrounded = %W[\n#{identification_number} #{identification_number}\n \n#{identification_number}\n]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
   end
 end
 
@@ -98,6 +160,26 @@ describe ActiveModel::Validations::ValidCifValidator do
         should_be_invalid(record, 'invalid')
       end
     end
+
+    it 'adds errors when there are surrounding characters' do
+      %w[S6185663I C2871341J G37880135 F43766880 A58818501 J27950005 V63423321].each do |identification_number|
+        surrounded = %W[junk#{identification_number} #{identification_number}junk junk#{identification_number}junk]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
+
+    it 'adds errors when there are surrounding lines' do
+      %w[S6185663I C2871341J G37880135 F43766880 A58818501 J27950005 V63423321].each do |identification_number|
+        surrounded = %W[\n#{identification_number} #{identification_number}\n \n#{identification_number}\n]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
   end
 end
 
@@ -121,6 +203,26 @@ describe ActiveModel::Validations::ValidNieValidator do
       %w[8527549Z 22472947S 000 S6185663I invalid_zip].each do |identification_number|
         record = build_record(identification_number)
         should_be_invalid(record, 'invalid')
+      end
+    end
+
+    it 'adds errors when there are surrounding characters' do
+      %w[Y8527549Z Y8305424T X9393496C X0012309G Y9370869Q Y2995306F].each do |identification_number|
+        surrounded = %W[junk#{identification_number} #{identification_number}junk junk#{identification_number}junk]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
+      end
+    end
+
+    it 'adds errors when there are surrounding lines' do
+      %w[Y8527549Z Y8305424T X9393496C X0012309G Y9370869Q Y2995306F].each do |identification_number|
+        surrounded = %W[\n#{identification_number} #{identification_number}\n \n#{identification_number}\n]
+        surrounded.each do |surrounded_identification_number|
+          record = build_record(surrounded_identification_number)
+          should_be_invalid(record)
+        end
       end
     end
   end


### PR DESCRIPTION
In Ruby, the characters `^` and `$` do not mean start/end of string, but start/end of line. The characters for start/end of string are `\A` and `\z`.

This produces an error where a string such as `"\n22472947S"` would be marked as valid, when it shouldn't be.

I've fixed this error here, and added the corresponding tests.